### PR TITLE
Fix/change init

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ let options = {
 // Create the force object with the options
 let force = new Force(options);
 
-// Initialises a .force project folder, and pulls from above org detail
+// Initialises a .force project folder
 force.init();
 
-// Pulls from from the org using some previoously initialised setting
+// Pulls from from the org using some previously initialised setting
 force.pull();
 
 // Pushes the current src folder (or whatever you set it to) to the org

--- a/lib/force.js
+++ b/lib/force.js
@@ -13,15 +13,19 @@ class Force {
    * @param {object} options - Some options see readme doc
    */
   constructor(options) {
-    this.options = options || {
-      // Set default options
+    // Set default options
+    this.options = {
       username: process.env.SF_USERNAME,
       password: process.env.SF_PASSWORD,
       token: process.env.SF_TOKEN,
       host: process.env.SF_HOST,
+      autoPull: false,
       apiVersion: 34.0,
       logLevel: 'info'
     }
+
+    // Mixin any provided options
+    Object.assign(this.options,options);
 
     if(!this._credentialsValid(this.options)) {
       throw `No valid credentials supplied. Set username, password and token as options or
@@ -101,7 +105,8 @@ class Force {
 
   /** Deletes all the content in the src and .force folder, take care... */
   reset() {
-    this.project.reset().catch(err => logger.log('error','Reset failed',err));
+    logger.log('info', `Removing '${this.project.forceDir}' and '${this.project.config.src}'`);
+    return this.project.reset().catch(err => logger.log('error','Reset failed',err));
   }
 }
 

--- a/lib/force/project.js
+++ b/lib/force/project.js
@@ -14,10 +14,11 @@ class Project {
     if(!this.isNew()) {
       this.config = this._readStoredConfig();
     } else {
-      this.config = force.options.project || {
-        // src: `${this.forceDir}/src`
-        src: `./src`
+      this.config = {
+        src: `${this.forceDir}/src`
       }
+
+      Object.assign(this.config,force.options.project);
     }
   }
 
@@ -26,11 +27,21 @@ class Project {
    * @return {Promise} The async result, generally of a pull
    */
   init() {
+    let options = this.force.options;
+
     logger.log('info',`Initializing .force/ folder if necessary`);
 
     // If new then do initial folder setup, else pull the metadata
-    if(this.isNew()) return this.setup(this.config);
-    else return this.force.pull();
+    if(this.isNew()) {
+      var setup = this.setup(this.config);
+    }
+
+    // If auto pull is set then do that
+    if(options.autoPull) {
+      return setup ? setup.then(() => this.force.pull()) : this.force.pull();
+    } else {
+      return Promise.resolve();
+    }
   }
 
   /**
@@ -46,9 +57,7 @@ class Project {
       fs.outputJson(`${dir}/project.json`, config),
       fs.outputJson(`${dir}/changes/log.json`, {}),
       this._setDefaultProjectXml()
-    ])
-    .then(result => this.force.pull()) // Pull metadata
-    .catch(err => console.log(err));   // Log error
+    ]);
   }
 
   /// Sets up the default project XML by copying the template if necessary

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,18 @@
+'use strict'
+
+// TODO Add actual tests
+var Force = require('../index.js');
+
+// Set options
+let options = {
+  autoPull: true,
+  logLevel: 'debug'
+}
+
+// Create object
+let force = new Force(options);
+
+// force.init();
+// force.pull();
+// force.push();
+// force.reset();


### PR DESCRIPTION
**New:**
- init() no longer automatically pulls directly after.

**Fixed:**
- reset() correctly returns the Promise
- Passing options to the constructor will mix the options in the defaults instead of overriding them with potentially null values
